### PR TITLE
Convenience operators for LinExpr and bug fix

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -33,6 +33,12 @@ impl From<Var> for LinExpr {
     }
 }
 
+impl From<f64> for LinExpr {
+  fn from(offset : f64) -> LinExpr {
+    LinExpr::new() + offset
+  }
+}
+
 impl Into<(Vec<i32>, Vec<f64>, f64)> for LinExpr {
   fn into(self) -> (Vec<i32>, Vec<f64>, f64) {
     (self.vars.into_iter().map(|e| e.index()).collect(), self.coeff, self.offset)
@@ -359,7 +365,7 @@ impl AddAssign<Var> for LinExpr {
 
 impl Sub for LinExpr {
   type Output = LinExpr;
-  fn sub(mut self, rhs: LinExpr) -> Self::Output {
+  fn sub(self, rhs: LinExpr) -> Self::Output {
     self + (-rhs)
   }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -21,9 +21,15 @@ pub struct LinExpr {
   offset: f64
 }
 
+impl<'a> From<&'a Var> for LinExpr {
+    fn from(var : &Var) -> LinExpr {
+        LinExpr::new() + var
+    }
+}
+
 impl From<Var> for LinExpr {
     fn from(var : Var) -> LinExpr {
-        LinExpr::new() + var
+        LinExpr::from(&var)
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -175,7 +175,14 @@ impl<'a, 'b> Add<&'b Var> for &'a Var {
   type Output = LinExpr;
   fn add(self, rhs: &Var) -> LinExpr { LinExpr::new().add_term(1.0, self.clone()).add_term(1.0, rhs.clone()) }
 }
-
+impl Add<f64> for Var {
+  type Output = LinExpr;
+  fn add(self, rhs: f64) -> LinExpr { LinExpr::new() + self + rhs }
+}
+impl<'a> Add<f64> for &'a Var {
+  type Output = LinExpr;
+  fn add(self, rhs: f64) -> LinExpr { LinExpr::new() + self.clone() + rhs }
+}
 
 /// `Var` - `Var` => `LinExpr`
 impl Sub for Var {
@@ -197,6 +204,18 @@ impl<'a, 'b> Sub<&'b Var> for &'a Var {
 impl Sub<LinExpr> for Var {
   type Output = LinExpr;
   fn sub(self, expr: LinExpr) -> LinExpr {  self + (-expr) }
+}
+impl<'a> Sub<LinExpr> for &'a Var {
+  type Output = LinExpr;
+  fn sub(self, expr: LinExpr) -> LinExpr {  self.clone() + (-expr) }
+}
+impl Sub<Var> for f64 {
+  type Output = LinExpr;
+  fn sub(self, rhs: Var) -> LinExpr { LinExpr::new() + self + (-rhs) }
+}
+impl<'a> Sub<&'a Var> for f64 {
+  type Output = LinExpr;
+  fn sub(self, rhs: &Var) -> LinExpr { LinExpr::new() + self + (-rhs.clone()) }
 }
 
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -315,10 +315,7 @@ impl Sub<f64> for LinExpr {
 impl Sub<LinExpr> for f64 {
   type Output = LinExpr;
   fn sub(self, mut rhs: LinExpr) -> Self::Output {
-    for c in rhs.coeff.iter_mut() {
-      *c *= -1.0;
-    }
-    rhs.add_constant(self)
+    self + (-rhs)
   }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -338,9 +338,15 @@ impl Neg for LinExpr {
 
 impl AddAssign for LinExpr {
     fn add_assign(&mut self, rhs: LinExpr) {
-        self.vars.extend(rhs.vars);
-        self.coeff.extend(rhs.coeff);
-        self.offset += rhs.offset;
+      for (var, &coeff) in rhs.vars.into_iter().zip(rhs.coeff.iter()) {
+        if let Some(idx) = self.vars.iter().position(|v| *v == var) {
+          self.coeff[idx] += coeff;
+        } else {
+          self.vars.push(var);
+          self.coeff.push(coeff);
+        }
+      }
+      self.offset += rhs.offset;
     }
 }
 
@@ -354,10 +360,7 @@ impl AddAssign<Var> for LinExpr {
 impl Sub for LinExpr {
   type Output = LinExpr;
   fn sub(mut self, rhs: LinExpr) -> Self::Output {
-    self.vars.extend(rhs.vars);
-    self.coeff.extend(rhs.coeff.into_iter().map(|c| -c));
-    self.offset -= rhs.offset;
-    self
+    self + (-rhs)
   }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -8,7 +8,7 @@ use super::{Var, Model};
 use error::Result;
 use itertools::*;
 
-use std::ops::{Add, Sub, Mul, Neg, AddAssign};
+use std::ops::{Add, Sub, Mul, Neg, AddAssign, Div};
 use std::iter::Sum;
 
 /// Linear expression of variables
@@ -196,7 +196,7 @@ impl<'a, 'b> Sub<&'b Var> for &'a Var {
 }
 impl Sub<LinExpr> for Var {
   type Output = LinExpr;
-  fn sub(self, expr: LinExpr) -> LinExpr { expr + (-self) }
+  fn sub(self, expr: LinExpr) -> LinExpr {  self + (-expr) }
 }
 
 
@@ -306,6 +306,17 @@ impl Add for LinExpr {
   }
 }
 
+impl Neg for LinExpr {
+  type Output = LinExpr;
+  fn neg(mut self) -> LinExpr {
+      for coeff in &mut self.coeff {
+        *coeff = -*coeff;
+      }
+      self.offset = -self.offset;
+      self
+  }
+}
+
 impl AddAssign for LinExpr {
     fn add_assign(&mut self, rhs: LinExpr) {
         self.vars.extend(rhs.vars);
@@ -338,6 +349,17 @@ impl Mul<f64> for LinExpr {
       *coeff *= rhs;
     }
     self.offset *= rhs;
+    self
+  }
+}
+
+impl Div<f64> for LinExpr {
+  type Output = LinExpr;
+  fn div(mut self, rhs: f64) -> Self::Output {
+    for coeff in &mut self.coeff {
+      *coeff /= rhs;
+    }
+    self.offset /= rhs;
     self
   }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -293,7 +293,7 @@ impl Sub<LinExpr> for f64 {
     for c in rhs.coeff.iter_mut() {
       *c *= -1.0;
     }
-    rhs.add_constant(-self)
+    rhs.add_constant(self)
   }
 }
 


### PR DESCRIPTION
Some operations I found convenient while working with this lib. Also fixed a bug in `impl Sub<LinExpr> for f64`
